### PR TITLE
Fix CSS when rendering site

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -62,7 +62,6 @@ website:
 format:
   html:
     theme:
-      light: "flatly"
-      dark: "darkly"
-    css: "content/custom.scss"
+      light: ["flatly", "custom.scss"]
+      dark: ["darkly", "custom.scss"]
     toc: true

--- a/content/slides/data-inspection.qmd
+++ b/content/slides/data-inspection.qmd
@@ -2,6 +2,8 @@
 title: "Data inspection tools"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 # Inspection with QGIS

--- a/content/slides/day-1-overview.qmd
+++ b/content/slides/day-1-overview.qmd
@@ -2,6 +2,8 @@
 title: "Day 1 overview"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 ## Workshop overview

--- a/content/slides/day-2-overview.qmd
+++ b/content/slides/day-2-overview.qmd
@@ -2,6 +2,8 @@
 title: "Day 2 overview"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 ## Review geospatial concepts

--- a/content/slides/geospatial-concepts-and-terms.qmd
+++ b/content/slides/geospatial-concepts-and-terms.qmd
@@ -2,6 +2,8 @@
 title: "Review: Foundational geospatial concepts and terms"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 # Data

--- a/content/slides/intro-to-github.qmd
+++ b/content/slides/intro-to-github.qmd
@@ -2,6 +2,8 @@
 title: "Intro to GitHub"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 ## Working "in the open"

--- a/content/slides/intro-to-jupyterlab.qmd
+++ b/content/slides/intro-to-jupyterlab.qmd
@@ -2,6 +2,8 @@
 title: "Intro to JupyterLab"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 ## JupyterHub

--- a/content/slides/open-science-and-data.qmd
+++ b/content/slides/open-science-and-data.qmd
@@ -2,6 +2,8 @@
 title: "Review of Open Science and Data Principles"
 subtitle: "QGreenland Researcher Workshop 2023"
 background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
+title-slide-attributes:
+  data-background-image: "/_media/DMS_1842643_12758_20180418_18111267_clipped.jpg"
 ---
 
 ## Open Science is here this year, get used to it!

--- a/custom.scss
+++ b/custom.scss
@@ -26,20 +26,21 @@
 }
 
 .slides:before {
-  content: "🛝";
-  /* content: "🖥️"; */
+  content: "🖥️";
   left: 5px;
   position: absolute;
 }
 
 .video:before {
   content: "🎥";
+  font-family: var(--bs-body-font-family);
   left: 5px;
   position: absolute;
 }
 
 .exercise:before {
   content: "💪";
+  font-family: var(--bs-body-font-family);
   left: 5px;
   position: absolute;
 }


### PR DESCRIPTION
I believe this broke when we added light/dark themes. But this breakage was never reflected in `quarto preview`.

EDIT: Second issue discovered that I thought was fixed -- the slide backgrounds aren't added to the `_site` directory when rendering anymore. Re-adding front-matter to the slides that we had previously deleted is working to resolve the problem.

TODO: Can we reproduce these two issues and file bugs with Quarto team?

1. CSS behavior different between `preview` and `render` modes
2. Slide background images not added to `_site` dir