### PR TITLE
callout note for "award number" question in cryocloud survey

### DIFF
--- a/content/prerequisites/index.md
+++ b/content/prerequisites/index.md
@@ -58,6 +58,12 @@ request an account. The following steps are **critical** to workshop participati
 * Fill out the [Getting Started
   Survey](https://docs.google.com/forms/d/e/1FAIpQLScb2B5LRy7qU9qDfUp5a51n87sumOxivXbQhc02wFX_FxEbXg/viewform).
   This survey will start the process of creating your account.
+
+::: {.callout-note}
+For the "Award Number" question in the survey, answer with "QGreenland workshop
+participant".
+:::
+
 * E-mail <cryocloud@mines.edu> to request account activation (provide your GitHub
   username).
     * You will shortly receive an invite (by e-mail from GitHub) to the CryoCloud GitHub


### PR DESCRIPTION
At least one of the participants got tripped up by the "Award Number" question:

> Contact your PI if you do not know under which award you are working. Please prioritize listing a NASA or Cryosphere award number if you have one and include what agency your award is through. If you do not have an award number, please provide reasoning.

Twila suggested "QGreenland workshop participant", which should be clear enough when approving accounts.