### PR TITLE
Improve legibility of text over background images

### DIFF
--- a/content/slides/custom.scss
+++ b/content/slides/custom.scss
@@ -10,6 +10,28 @@ h1, h2, h3, h4, h5, h6, body {
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 1.0);
 }
 
+/*
+blur, desaturate, and dim backgrounds to make text easier to read
+
+NOTE: This is currently _not supported_ in Firefox because Firefox does not
+support the `:has()` selector (for the last 16 years:
+https://bugzilla.mozilla.org/show_bug.cgi?id=418039).
+*/
+html .backgrounds {
+   -webkit-filter: blur(4px) saturate(.5) brightness(.8);
+   -moz-filter: blur(4px) saturate(.7) brightness(.9);
+   -o-filter: blur(4px) saturate(.7) brightness(.9);
+   -ms-filter: blur(4px) saturate(.7) brightness(.9);
+   filter: blur(4px) saturate(.7) brightness(.9);
+}
+.slides:has(> #title-slide:not([hidden])) ~ .backgrounds {
+   -webkit-filter: blur(0px) saturate(1) brightness(1);
+   -moz-filter: blur(0px) saturate(1) brightness(1);
+   -o-filter: blur(0px) saturate(1) brightness(1);
+   -ms-filter: blur(0px) saturate(1) brightness(1);
+   filter: blur(0px) saturate(1) brightness(1);
+}
+
 .backgrounds {
   background-size: cover;
 }

--- a/content/slides/custom.scss
+++ b/content/slides/custom.scss
@@ -11,18 +11,19 @@ h1, h2, h3, h4, h5, h6, body {
 }
 
 /*
-blur, desaturate, and dim backgrounds to make text easier to read
+blur, desaturate, and dim backgrounds of non-title slides to make text easier
+to read.
 
-NOTE: This is currently _not supported_ in Firefox because Firefox does not
-support the `:has()` selector (for the last 16 years:
-https://bugzilla.mozilla.org/show_bug.cgi?id=418039).
+NOTE: Firefox does not support the `:has()` selector (for the last 16 years:
+https://bugzilla.mozilla.org/show_bug.cgi?id=418039), so in Firefox all slides
+will appear "dim".
 */
 html .backgrounds {
-   -webkit-filter: blur(4px) saturate(.5) brightness(.8);
-   -moz-filter: blur(4px) saturate(.7) brightness(.9);
-   -o-filter: blur(4px) saturate(.7) brightness(.9);
-   -ms-filter: blur(4px) saturate(.7) brightness(.9);
-   filter: blur(4px) saturate(.7) brightness(.9);
+   -webkit-filter: blur(4px) saturate(.7) brightness(.8);
+   -moz-filter: blur(4px) saturate(.7) brightness(.8);
+   -o-filter: blur(4px) saturate(.7) brightness(.8);
+   -ms-filter: blur(4px) saturate(.7) brightness(.8);
+   filter: blur(4px) saturate(.7) brightness(.8);
 }
 .slides:has(> #title-slide:not([hidden])) ~ .backgrounds {
    -webkit-filter: blur(0px) saturate(1) brightness(1);

--- a/content/slides/data-formats-and-inspection.md
+++ b/content/slides/data-formats-and-inspection.md
@@ -3,8 +3,6 @@ title: "Data/metadata inspection"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 30
 background-image: "https://live.staticflickr.com/65535/50238782702_020e861875_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50238782702_020e861875_k.jpg"
 ---
 
 # Geospatial data formats

--- a/content/slides/fixing-common-data-metadata-issues.md
+++ b/content/slides/fixing-common-data-metadata-issues.md
@@ -3,8 +3,6 @@ title: "Fixing common data/metadata issues"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 60
 background-image: "https://live.staticflickr.com/65535/50237921938_0e9dc8978a_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50237921938_0e9dc8978a_k.jpg"
 ---
 
 ## What tool should I use?

--- a/content/slides/geospatial-concepts-and-terms.md
+++ b/content/slides/geospatial-concepts-and-terms.md
@@ -3,8 +3,6 @@ title: "Review: Geospatial concepts and terms"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 20
 background-image: "https://live.staticflickr.com/65535/50237698987_d346b23e9b_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50237698987_d346b23e9b_k.jpg"
 ---
 
 # Data

--- a/content/slides/geospatial-data-transformations.md
+++ b/content/slides/geospatial-data-transformations.md
@@ -3,8 +3,6 @@ title: "Geospatial data transformations"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 70
 background-image: "https://live.staticflickr.com/65535/50268301128_34e0e30e82_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50268301128_34e0e30e82_k.jpg"
 ---
 
 ## What tool should I use?

--- a/content/slides/intro-to-github.md
+++ b/content/slides/intro-to-github.md
@@ -3,8 +3,6 @@ title: "Intro to GitHub"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 40
 background-image: "https://live.staticflickr.com/65535/50237698987_d346b23e9b_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50237698987_d346b23e9b_k.jpg"
 ---
 
 <!-- TODO:

--- a/content/slides/intro-to-jupyterlab.md
+++ b/content/slides/intro-to-jupyterlab.md
@@ -3,8 +3,6 @@ title: "Intro to JupyterLab"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 10
 background-image: "https://live.staticflickr.com/65535/50237921218_962ba3da87_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50237921218_962ba3da87_k.jpg"
 ---
 
 # Note

--- a/content/slides/open-science-and-data.md
+++ b/content/slides/open-science-and-data.md
@@ -3,8 +3,6 @@ title: "Review of Open Science and Data Principles"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 50
 background-image: "https://live.staticflickr.com/65535/50238785027_7afce99e9c_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50238785027_7afce99e9c_k.jpg"
 ---
 
 ## Open Science is here this year, get used to it!

--- a/content/slides/symbology-with-qgis.md
+++ b/content/slides/symbology-with-qgis.md
@@ -3,8 +3,6 @@ title: "Symbolizing geospatial data with QGIS"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 80
 background-image: "https://live.staticflickr.com/65535/50268975211_f55d6b4e1c_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50268975211_f55d6b4e1c_k.jpg"
 ---
 
 <!-- alex disable color colors -->

--- a/content/slides/workshop-overview.md
+++ b/content/slides/workshop-overview.md
@@ -3,8 +3,6 @@ title: "Workshop overview"
 subtitle: "QGreenland Researcher Workshop 2023"
 index: 0
 background-image: "https://live.staticflickr.com/65535/50268354463_60d684d945_k.jpg"
-title-slide-attributes:
-  data-background-image: "https://live.staticflickr.com/65535/50268354463_60d684d945_k.jpg"
 ---
 
 ## Workshop goals

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python ~=3.10
 
-  - quarto ~=1.2.335
+  - quarto ~=1.3.340
   - jupyter ~=1.0.0
   - xarray ~=2023.03
   - rioxarray ~=0.14.1


### PR DESCRIPTION
In Firefox, all slide backgrounds will appear blurred, since Firefox has still not implemented `:has()` CSS selector after 16 years. See the comments for more.

In every other browser, the slides will beautifully fade from a crisp background image on the title slide to a blurred background image on the remaining slides.