### PR TITLE
Remove the table of contents slide from slideshows

### DIFF
--- a/content/slides/_metadata.yml
+++ b/content/slides/_metadata.yml
@@ -1,7 +1,7 @@
 format:
   revealjs:
     strip-comments: true
-    toc: true
+    toc: false
     toc-depth: 2
     overview: true
 


### PR DESCRIPTION
These do not work very well (they are often truncated) and are just another slide we have to move past to get to the content. If/when we want to show an overview of the contents, the 'hamburger' menu is much more convenient. It's also accessible from any slide.